### PR TITLE
Cleanup txt files from previous run - extraction

### DIFF
--- a/extract-doc-modules.sh
+++ b/extract-doc-modules.sh
@@ -81,6 +81,7 @@ MODULE_PATH=$REPO_PATH/$MOD_DIR
 
 # Cleanup from a previous run
 rm -f assemblies.tmp nested-assemblies.tmp modules.tmp &>/dev/null
+rm -f assemblies.txt nested-assemblies.txt &>/dev/null
 
 # Copy assemblies found in "FILE" to assemblies.tmp
 while IFS= read -r line; do


### PR DESCRIPTION
If I forget to delete them manually, the list of assemblies piles up from the previous run.
I don't want to be deleting them manually every time I run the script.