### PR TITLE
Fix empty lines removal

### DIFF
--- a/extract-doc-modules.sh
+++ b/extract-doc-modules.sh
@@ -136,7 +136,7 @@ sed -i 's/\[.*\]$//' modules.tmp
 sed -i "s|^|$MODULE_PATH|g; s|\/\/|\/|g" modules.tmp
 
 # Sort module names and remove blank lines.
-sort modules.tmp | uniq | grep -v '^$' >&1
+sort modules.tmp | uniq | grep -v "^$MODULE_PATH$" >&1
 
 # Clean up temporary files.
 rm *.tmp &>/dev/null


### PR DESCRIPTION
The empty lines are not empty because all lines are prepended with the MODULE_PATH.

This fixes it.

It caused a lot of trouble because the module dir was included in the list of modules and Vale test ended up running on the whole module dir each time :laughing: 