### PR TITLE
extract doc modules: Remove modules with attributes in file name

### DIFF
--- a/extract-doc-modules.sh
+++ b/extract-doc-modules.sh
@@ -131,6 +131,8 @@ done < "$FILE"
 sed -i 's/\/\/.*//' modules.tmp
 # Remove files that you don't want to check.
 sed -i 's/proc_providing-feedback-on-red-hat-documentation.adoc//g' modules.tmp
+# Remove files containing attributes - {}
+sed -i '/{/d' modules.tmp
 # Remove leveloffsets and empty square brackets.
 sed -i 's/\[.*\]$//' modules.tmp
 # Prepend module path


### PR DESCRIPTION
Removes modules whose file names contain attributes because we can't run checks on them.

Example: ../../foreman-documentation/guides/common/modules/proc_configuring-repositories-{build}.adoc