### PR TITLE
Fix CQA steps check

### DIFF
--- a/cqa-mod-checks/cqa-mod-checks.sh
+++ b/cqa-mod-checks/cqa-mod-checks.sh
@@ -264,7 +264,7 @@ echo -e "$CHECK:\n" >> $OUTPUT
 echo -e "- $CHECK" >> $SUMMARY
 cat $MODULES | xargs -I {} bash -c '
   steps=$(grep -E "^\. [A-Z]" "$1" | wc -l)
-  if (( steps >= 10 )); then
+  if (( steps > 10 )); then
     echo "- $1"
   fi
 ' _ {} >> "$OUTPUT"

--- a/cqa-mod-checks/cqa-mod-checks.sh
+++ b/cqa-mod-checks/cqa-mod-checks.sh
@@ -262,7 +262,7 @@ echo -e "- _Done_\n" >> $OUTPUT
 CHECK="Procedure longer than 10 steps found"
 echo -e "$CHECK:\n" >> $OUTPUT
 echo -e "- $CHECK" >> $SUMMARY
-cat $MODULES | xargs -I {} sh -c '
+cat $MODULES | xargs -I {} bash -c '
   steps=$(grep -E "^\. [A-Z]" "$1" | wc -l)
   if (( steps >= 10 )); then
     echo "- $1"


### PR DESCRIPTION
- Use bash to eliminate error: `_: 3: steps: not found`
- Use exact number of steps as threshold - unless there's a reason for `greater or equal to 10`